### PR TITLE
Bug 1164123 - meta theme-color should match the gaia-header theme col…

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
 
     <link rel="stylesheet" type="text/css" href="app://theme.gaiamobile.org/shared/elements/gaia-theme/gaia-theme.css">
     <meta name="theme-color" content="var(--header-background)">
+    <meta name="theme-group" content="theme-settings">
   </head>
   <body class="theme-settings">
     <section id="main" class="panel">


### PR DESCRIPTION
…or when possible r=hub
